### PR TITLE
change computation of start and end values, if scrolling inside an independent element 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-magic-scroll",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A react component which has a scrollbar but renders (and loads) only visible elements to improve browser performance. The elements need to have the same height.",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,8 @@
   },
   "homepage": "https://github.com/justsocialapps/just-magic-scroll#readme",
   "peerDependencies": {
-    "react": "15.x.x"
+    "react": "15.x.x",
+    "prop-types": "15.x.x"
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -47,7 +48,7 @@
     "expect-jsx": "^2.6.0",
     "jsdom": "^9.4.1",
     "mocha": "^2.5.3",
-    "react-addons-test-utils": "^15.2.1",
-    "react-dom": "^15.3.2"
+    "react-dom": "^15.6.2",
+    "prop-types": "15.6.1"
   }
 }

--- a/src/test/js/magic-scroll.spec.js
+++ b/src/test/js/magic-scroll.spec.js
@@ -1,7 +1,7 @@
 /*eslint-env node, mocha */
 
 import React from 'react';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import expect from 'expect';
 import expectElement from 'expect-element';
 expect.extend(expectElement);


### PR DESCRIPTION
- if the scrollbar just scrolls the content of a container, scrollTop
  can be used instead of using the overall top value of the container
  to compute the current start and end values
- upgraded to react 15.6.2 and migrated to the prop-types package to
  remove deprecation warnings
- updated version to 0.0.4